### PR TITLE
allow coloring methods to be used outside package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [1.0.0]
+## [1.0.2]
 
-### Added
+### Changed
 
-- Script that manages different user defined color maps and prioritizes them for object coloring. 
+- Changed scope to public for Interaction.ApplyColorsToAll and Interaction.ApplyColors
 
 ## [1.0.1]
 
@@ -18,3 +18,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Changed namespace
 - made no override color a static readonly variable
 - fixed issue where the ColorSetLayer would hold a reference to a temporary variable dictionary instead of a standalone copy
+
+## [1.0.0]
+
+### Added
+
+- Script that manages different user defined color maps and prioritizes them for object coloring.

--- a/Runtime/Scripts/Interaction.cs
+++ b/Runtime/Scripts/Interaction.cs
@@ -28,7 +28,7 @@ namespace Netherlands3D.SubObjects
             }
         }
 
-        internal static void ApplyColorsToAll(Dictionary<string, Color> colorMap)
+        public static void ApplyColorsToAll(Dictionary<string, Color> colorMap)
         {
             Debug.Log("start coloring all");
             if (mappings == null)
@@ -42,7 +42,7 @@ namespace Netherlands3D.SubObjects
             }
         }
 
-        private static void ApplyColors(Dictionary<string, Color> colorMap, ObjectMapping mapping)
+        public static void ApplyColors(Dictionary<string, Color> colorMap, ObjectMapping mapping)
         {
             Debug.Log("coloring");
             Debug.Log("mapcount "+ colorMap.Count);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eu.netherlands3d.subobjects",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "displayName": "Netherlands3D - Subobjects",
   "description": "Package get acces to Subobjects of loaded tiles",
   "unity": "2022.2",


### PR DESCRIPTION
Fixes problem where other package(s)/projects could not use Interaction.ApplyColorsToAll and Interaction.ApplyColors method.
(Currently a problem when trying to highlight clicked buildings BAG info)